### PR TITLE
Add basic support for returning the correct Content-Type after resizing images

### DIFF
--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -3,11 +3,20 @@ package handlers
 import (
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 	"strconv"
 
 	"github.com/dantdj/GoResize/pkg/resizing"
 	"github.com/labstack/echo/v4"
 )
+
+// Default encoding options for different filetypes.
+var contentTypes = map[string]string{
+	".jpeg": "image/jpeg",
+	".jpg":  "image/jpeg",
+	".png":  "image/png",
+	".webp": "image/webp",
+}
 
 func ResizeHandler(ctx echo.Context) error {
 	formData, _ := ctx.FormFile("file")
@@ -24,7 +33,7 @@ func ResizeHandler(ctx echo.Context) error {
 		return ctx.NoContent(500)
 	}
 
-	return ctx.Blob(200, "image/png", resized)
+	return ctx.Blob(200, contentTypes[filepath.Ext(formData.Filename)], resized)
 }
 
 func HealthCheckHandler(ctx echo.Context) error {


### PR DESCRIPTION
Currently based on file extension only - should change this to be from the magic bytes in the file itself (as Lilliput will decode)